### PR TITLE
Better handling of text properties and minor speed-up

### DIFF
--- a/from.py
+++ b/from.py
@@ -29,12 +29,12 @@ with open ('gtexfix_latex', 'rb') as fp:
     latex = pickle.load(fp)
 
 ### Replace weird characters introduced by translation
-trtext=re.sub('\u200B',' ',source)
+trtext = source.replace('\u200B',' ')
 
 ### Fix spacing
-trtext = re.sub(r'\\ ',r'\\',trtext)
-trtext = re.sub(' ~ ','~',trtext)
-trtext = re.sub(' {','{',trtext)
+trtext = trtext.replace(r'\\ ',r'\\')
+trtext = trtext.replace(' ~ ','~')
+trtext = trtext.replace(' {','{')
 
 ### Restore LaTeX and formulas
 here=0
@@ -66,6 +66,9 @@ for m in re.finditer('\[ *[012][\.\,][0-9]+\]',trtext):
     here=m.end()
 newtext += trtext[here:]
 trtext=newtext
+
+### Fix spacing
+trtext = trtext.replace(' [','[')
 
 ### Restore comments
 here=0

--- a/to.py
+++ b/to.py
@@ -91,7 +91,9 @@ with open('gtexfix_latex', 'wb') as fp:
 ### Replace LaTeX commands, formulas and comments by tokens
 # Regular expression r'(\$+)(?:(?!\1)[\s\S])*\1' for treatment of $...$ and $$...$$ from:
 # https://stackoverflow.com/questions/54663900/how-to-use-regular-expression-to-remove-all-math-expression-in-latex-file
-recommand = re.compile(r'___GTEXFIXCOMMENT[0-9]*___|\\title|\\chapter\**|\\section\**|\\subsection\**|\\subsubsection\**|~*\\footnote[0-9]*|(\$+)(?:(?!\1)[\s\S])*\1|~*\\\w*\s*{[^}]*}\s*{[^}]*}|~*\\\w*\s*{[^}]*}|~*\\\w*')
+recommand = re.compile(r'___GTEXFIXCOMMENT[0-9]*___|\\\\|\\title|\\chapter\**|\\section\**|\\subsection\**|\\subsubsection\**|\\subparagraph\**'
+                       +r'|\\textbf\**|\\textit\**|\\textsc\**|\\textsf\**|\\textsl\**|\\texttt\**|\\emph\**|\\underline\**'
+                       +r'|~*\\footnote[0-9]*|(\$+)(?:(?!\1)[\s\S])*\1|~*\\\w*\s*{[^}]*}\s*{[^}]*}|~*\\\w*\s*{[^}]*}|~*\\\w*')
 commands=[]
 for m in recommand.finditer(text):
     commands.append(m.group())


### PR DESCRIPTION
Text within `\textbf` etc is now translated.

`\\` are now kept (closes #6 although the ` / ` issue remains).

Also replaced `re.sub` with `string.replace` which should be faster and removed space before `[` which keeps the code looking better.

Feel free to merge, I give full consent to include this code in gtexfix.